### PR TITLE
Adding examples from my own experience

### DIFF
--- a/ssms/install/command-line-examples.md
+++ b/ssms/install/command-line-examples.md
@@ -62,10 +62,10 @@ Update an SSMS installation via the command line with progress displayed and no 
 
 ## Use --layout to create a network layout or local cache
 
-Create a layout that includes SSMS and Copilot in SSMS, and the English language pack:
+Create a layout that includes SSMS and Integration Services in SSMS, and the English language pack:
 
 ```cmd
-vs_ssms.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SSMS.Component.Copilot --includeRecommended
+vs_ssms.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SSMS.Component.IS --includeRecommended
 ```
 
 Create a layout with two workloads and one optional component in three languages:
@@ -95,29 +95,27 @@ vs_SSMS.exe --layout C:\SSMS_Layout --add Microsoft.Component.HelpViewer
 
 ## Install a layout
 
-Once a layout is created, it can be copied to an offline machine for installation. If the layout was created using:
+Once a layout is created, it can be copied to an offline machine for installation. Components identified will need to be lincluded in the offline layout already (see 'complete local layout' mentioned in a prior example):
 
 ```cmd
-vs_SSMS.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SSMS.Component.Copilot --includeRecommended
+vs_SSMS.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SSMS.Component.IS --includeRecommended
 ```
 
-Install SSMS with Copilot from the layout using:
+To install SSMS with Integration Services support from the layout, run:
 
 ```cmd
-vs_SSMS.exe --noWeb --noUpdateInstaller --add Microsoft.SSMS.Component.Copilot --includeRecommended --passive
+vs_SSMS.exe --noWeb --noUpdateInstaller --add Microsoft.SSMS.Component.IS --includeRecommended --passive
 ```
 
-Install SSMS with Integration Services, Reporting Services, and Copilot from the layout using:
+To install SSMS with Integration Services and Reporting Services support, run:
 
 ```cmd
-vs_SSMS.exe --noWeb --noUpdateInstaller --add Microsoft.SSMS.Component.Copilot --add Microsoft.SSMS.Component.IS --add Microsoft.SSMS.Component.RS --includeRecommended --passive
+vs_SSMS.exe --noWeb --noUpdateInstaller --add Microsoft.SSMS.Component.IS --add Microsoft.SSMS.Component.RS --includeRecommended --passive
 ```
 
 ## Modifying an existing installation
 
-Once SQL Server Management Studio is installed, modifications to the components installed can be modified using `C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe` (default location).
-
-To update SSMS using an offline layout to ensure desired components are included in the installation, and then modify SSMS to add Analysis Services, Integration Services, Reporting Services, and Copilot components, run:
+To update SSMS using an offline layout to ensure desired components are included in the installation, and then modify SSMS to add Analysis Services, Integration Services, and Reporting Services components, run:
 
 ```cmd
 cd C:\SSMSLayout

--- a/ssms/install/command-line-examples.md
+++ b/ssms/install/command-line-examples.md
@@ -115,7 +115,7 @@ vs_SSMS.exe --noWeb --noUpdateInstaller --add Microsoft.SSMS.Component.IS --add 
 
 ## Modifying an existing installation
 
-To update SSMS using an offline layout to ensure desired components are included in the installation, and then modify SSMS to add Analysis Services, Integration Services, and Reporting Services components, run:
+To update SSMS to include additional components, create a layout using the examples above that include your desired components. To modify SSMS to add Analysis Services, Integration Services, and Reporting Services components by using the offline layout that includes the components, run:
 
 ```cmd
 cd C:\SSMS_Layout

--- a/ssms/install/command-line-examples.md
+++ b/ssms/install/command-line-examples.md
@@ -29,13 +29,13 @@ For lists of the workloads and components that you can install by using the comm
 Install a minimal instance of SSMS, with no interactive prompts, but progress displayed:
 
 ```cmd
-vs_ssms.exe --installPath C:\SSMS21 --passive --norestart
+vs_ssms.exe --installPath C:\SSMSLayout --passive --norestart
 ```
 
 Install SSMS silently, with the Italian language pack, returning only when the product is installed:
 
 ```cmd
-vs_ssms.exe --installPath C:\SSMS21 --addProductLang it-it --quiet --wait
+vs_ssms.exe --installPath C:\SSMSLayout --addProductLang it-it --quiet --wait
 ```
 
 ## Install workloads
@@ -57,7 +57,7 @@ vs_ssms.exe --add Microsoft.SqlServer.Workload.SSMS.BI --includeRecommended --pa
 Update an SSMS installation via the command line with progress displayed and no interactive prompts. You can't initiate the installer programmatically from the same directory that the installer resides in.
 
 ```cmd
-"C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe" update --passive --norestart --installPath "C:\SSMS21"
+"C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe" update --passive --norestart --installPath "C:\SSMSLayout"
 ```
 
 ## Use --layout to create a network layout or local cache
@@ -65,7 +65,7 @@ Update an SSMS installation via the command line with progress displayed and no 
 Create a layout that includes SSMS and Copilot in SSMS, and the English language pack:
 
 ```cmd
-vs_ssms.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SqlServer.Workload.SSMS.AI --includeRecommended
+vs_ssms.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SSMS.Component.Copilot --includeRecommended
 ```
 
 Create a layout with two workloads and one optional component in three languages:
@@ -74,19 +74,57 @@ Create a layout with two workloads and one optional component in three languages
 vs_ssms.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SqlServer.Workload.SSMS.HybridAndMigration --add Microsoft.SqlServer.Workload.SSMS.CodeTools --add Microsoft.Component.HelpViewer --lang en-US de-DE ja-JP
 ```
 
+To create a complete local layout for SQL Server Management Studio and all languages, run:
+
+```cmd
+vs_SSMS.exe --layout C:\SSMS_Layout --all
+```
+
+To create a local layout for SQL Server Management Studio that limits the components to only the Integration Services and Reporting Services component, run:
+
+```cmd
+vs_SSMS.exe --layout C:\SSMS_Layout --add Microsoft.SSMS.Component.IS --add Microsoft.SSMS.Component.RS
+```
+
+To create a local layout for SQL Server Management Studio that limits the components to only the offline help content, run:
+
+```cmd
+vs_SSMS.exe --layout C:\SSMS_Layout --add Microsoft.Component.HelpViewer
+```
+
+
 ## Install a layout
 
 Once a layout is created, it can be copied to an offline machine for installation. If the layout was created using:
 
 ```cmd
-vs_ssms.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SqlServer.Workload.SSMS.AI --includeRecommended
+vs_SSMS.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SSMS.Component.Copilot --includeRecommended
 ```
 
-Install SSMS from the layout using:
+Install SSMS with Copilot from the layout using:
 
 ```cmd
-C:\SSMS_Layout\vs_SSMS.exe --noWeb --noUpdateInstaller --add Microsoft.SqlServer.Workload.SSMS.AI --includeRecommended --passive
+vs_SSMS.exe --noWeb --noUpdateInstaller --add Microsoft.SSMS.Component.Copilot --includeRecommended --passive
 ```
+
+Install SSMS with Integration Services, Reporting Services, and Copilot from the layout using:
+
+```cmd
+vs_SSMS.exe --noWeb --noUpdateInstaller --add Microsoft.SSMS.Component.Copilot --add Microsoft.SSMS.Component.IS --add Microsoft.SSMS.Component.RS --includeRecommended --passive
+```
+
+## Modifying an existing installation
+
+Once SQL Server Management Studio is installed, modifications to the components installed can be modified using `C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe` (default location).
+
+To update SSMS using an offline layout to ensure desired components are included in the installation, and then modify SSMS to add Analysis Services, Integration Services, Reporting Services, and Copilot components, run:
+
+```cmd
+cd C:\SSMSLayout
+vs_SSMS.exe update --noWeb --quiet --wait --norestart
+vs_SSMS.exe modify --noWeb --productID Microsoft.VisualStudio.Product.SSMS --channelID SSMS.21.SSMS.Release --add Microsoft.SSMS.Component.AS --add Microsoft.SSMS.Component.IS --add Microsoft.SSMS.Component.RS --quiet --norestart
+```
+
 
 ## Related content
 

--- a/ssms/install/command-line-examples.md
+++ b/ssms/install/command-line-examples.md
@@ -29,13 +29,13 @@ For lists of the workloads and components that you can install by using the comm
 Install a minimal instance of SSMS, with no interactive prompts, but progress displayed:
 
 ```cmd
-vs_ssms.exe --installPath C:\SSMSLayout --passive --norestart
+vs_SSMS.exe --passive --norestart
 ```
 
 Install SSMS silently, with the Italian language pack, returning only when the product is installed:
 
 ```cmd
-vs_ssms.exe --installPath C:\SSMSLayout --addProductLang it-it --quiet --wait
+vs_SSMS.exe --addProductLang it-it --quiet --wait
 ```
 
 ## Install workloads
@@ -43,21 +43,21 @@ vs_ssms.exe --installPath C:\SSMSLayout --addProductLang it-it --quiet --wait
 Install SSMS with Git integration, with the user interface displayed in a non-interactive manner:
 
 ```cmd
-vs_ssms.exe --add Microsoft.SqlServer.Workload.SSMS.CodeTools --includeRecommended --passive
+vs_SSMS.exe --add Microsoft.SqlServer.Workload.SSMS.CodeTools --includeRecommended --passive
 ```
 
 Install SSMS with all components in the Business Intelligence workload, with the user interface displayed in a non-interactive manner:
 
 ```cmd
-vs_ssms.exe --add Microsoft.SqlServer.Workload.SSMS.BI --includeRecommended --passive --norestart
+vs_SSMS.exe --add Microsoft.SqlServer.Workload.SSMS.BI --includeRecommended --passive --norestart
 ```
 
 ## Update
 
-Update an SSMS installation via the command line with progress displayed and no interactive prompts. You can't initiate the installer programmatically from the same directory that the installer resides in.
+Update an SSMS installation via the command line quietly
 
 ```cmd
-"C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe" update --passive --norestart --installPath "C:\SSMSLayout"
+vs_SSMS.exe update --noWeb --quiet --wait --norestart
 ```
 
 ## Use --layout to create a network layout or local cache
@@ -65,13 +65,13 @@ Update an SSMS installation via the command line with progress displayed and no 
 Create a layout that includes SSMS and Integration Services in SSMS, and the English language pack:
 
 ```cmd
-vs_ssms.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SSMS.Component.IS --includeRecommended
+vs_SSMS.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SSMS.Component.IS --includeRecommended
 ```
 
 Create a layout with two workloads and one optional component in three languages:
 
 ```cmd
-vs_ssms.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SqlServer.Workload.SSMS.HybridAndMigration --add Microsoft.SqlServer.Workload.SSMS.CodeTools --add Microsoft.Component.HelpViewer --lang en-US de-DE ja-JP
+vs_SSMS.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SqlServer.Workload.SSMS.HybridAndMigration --add Microsoft.SqlServer.Workload.SSMS.CodeTools --add Microsoft.Component.HelpViewer --lang en-US de-DE ja-JP
 ```
 
 To create a complete local layout for SQL Server Management Studio and all languages, run:

--- a/ssms/install/command-line-examples.md
+++ b/ssms/install/command-line-examples.md
@@ -118,7 +118,7 @@ vs_SSMS.exe --noWeb --noUpdateInstaller --add Microsoft.SSMS.Component.IS --add 
 To update SSMS using an offline layout to ensure desired components are included in the installation, and then modify SSMS to add Analysis Services, Integration Services, and Reporting Services components, run:
 
 ```cmd
-cd C:\SSMSLayout
+cd C:\SSMS_Layout
 vs_SSMS.exe update --noWeb --quiet --wait --norestart
 vs_SSMS.exe modify --noWeb --productID Microsoft.VisualStudio.Product.SSMS --channelID SSMS.21.SSMS.Release --add Microsoft.SSMS.Component.AS --add Microsoft.SSMS.Component.IS --add Microsoft.SSMS.Component.RS --quiet --norestart
 ```

--- a/ssms/install/command-line-examples.md
+++ b/ssms/install/command-line-examples.md
@@ -98,7 +98,7 @@ vs_SSMS.exe --layout C:\SSMS_Layout --add Microsoft.Component.HelpViewer
 Once a layout is created, it can be copied to an offline machine for installation. Components identified will need to be lincluded in the offline layout already (see 'complete local layout' mentioned in a prior example):
 
 ```cmd
-vs_SSMS.exe --layout "C:\SSMS_Layout" --lang en-US --add Microsoft.SSMS.Component.IS --includeRecommended
+vs_SSMS.exe --lang en-US --add Microsoft.SSMS.Component.IS --includeRecommended
 ```
 
 To install SSMS with Integration Services support from the layout, run:

--- a/ssms/install/create-offline.md
+++ b/ssms/install/create-offline.md
@@ -28,7 +28,19 @@ Open a command prompt with administrator privileges, navigate to the directory w
 
 You can install a language other than English by changing `en-US` to a locale from the [list of language locales](command-line-parameters.md#list-of-language-locales), and you can use the [list of component IDs](workload-component-ids.md) to further customize your local layout.
 
-To create a complete local layout for SQL Server Management Studio, run:
+To create a complete local layout for SQL Server Management Studio and all languages, run:
+
+```cmd
+vs_SSMS.exe --layout C:\SSMS_Layout --all
+```
+
+To create a local layout for SQL Server Management Studio that limits the components to only the Integration Services and Reporting Services component, run:
+
+```cmd
+vs_SSMS.exe --layout C:\SSMS_Layout --add Microsoft.SSMS.Component.IS --add Microsoft.SSMS.Component.RS
+```
+
+To create a local layout for SQL Server Management Studio that limits the components to only the offline help content, run:
 
 ```cmd
 vs_SSMS.exe --layout C:\SSMS_Layout --add Microsoft.Component.HelpViewer

--- a/ssms/install/install.md
+++ b/ssms/install/install.md
@@ -104,6 +104,8 @@ vs_SSMS.exe --locale en-US
 
 The installer remembers this setting when you run it again. The installer supports these language locales: `zh-cn`, `zh-tw`, `cs-cz`, `en-us`, `es-es`, `fr-fr`, `de-de`, `it-it`, `ja-jp`, `ko-kr`, `pl-pl`, `pt-br`, `ru-ru`, and `tr-tr`.
 
+For more command-line examples, see [Command-line parameter examples](command-line-examples.md).
+
 ## Step 7 - Select the installation location (optional)
 
 You can reduce the installation footprint of SSMS on your system drive. For more information, see [Select installation locations for SQL Server Management Studio](select-install-location.md).


### PR DESCRIPTION
I aligned the examples to use the same path for the layout, C:\SSMS_Layout\ and included numerous vs_SSMS.exe examples from my testing of fresh installations, updates to existing installations, and ensuring that IS, since my company has a good amount of SSIS still in use, is added to the SSMS installation. The existing examples lacked the modify example. 