### PR TITLE
Update web browser settings information for SSMS

### DIFF
--- a/ssms/sql-server-management-studio-web-browser.md
+++ b/ssms/sql-server-management-studio-web-browser.md
@@ -29,6 +29,8 @@ To control what browser is invoked from SSMS, change the setting, **Use system d
 
 - For SSMS 19.0.2 and below, the default value is *True*. When set to *True*, SSMS invokes Microsoft Internet Explorer for Microsoft Entra authentication. Internet Explorer was retired in June 2022. If you encounter an error message titled `Unsupported browser`, change **Use system default web browser** to *False* and configure the default browser for the workstation.
 
+- For SSMS 22 and higher, this setting cannot be configured.
+
 ## Related content
 
 - [General user interface elements](general-user-interface-elements.md)


### PR DESCRIPTION
Clarified the behavior of the 'Use system default web browser' setting in SSMS versions. 

I don't know exactly what version stopped allowing configuration, but it's no longer configurable in SSMS 22.6.

(This isn't a problem - I just used to use the built-in browser for funny demos, but it doesn't appear to be accessible anymore.)