### PR TITLE
Document InformationDisabled feedback group policy for SSMS

### DIFF
--- a/ssms/feedback-survey-policies.md
+++ b/ssms/feedback-survey-policies.md
@@ -22,12 +22,13 @@ One of the main categories included in the Visual Studio ADMX templates is feedb
 
 ## Supported policies
 
-Two feedback group policies exist for SSMS.
+The following feedback group policies exist for SSMS:
 
 | Name | Description |
 | --- | --- |
 | `SurveysDisabled` | Controls whether the user receives survey links in SSMS. If enabled, SSMS and the Visual Studio Installer don't display any product survey requests or links to surveys to the user. |
 | `ProductFeedbackDisabled` | Controls whether the user can submit feedback through SSMS. If enabled, SSMS and the Visual Studio Installer don't allow users to submit feedback to Microsoft. Examples include, but aren't limited to reporting feedback, submitting suggestions, and providing feedback on features via a thumbs up/down control. |
+| `InformationDisabled` | Controls whether the user receives informational announcements in SSMS. If enabled, SSMS and the Visual Studio Installer don't display informational announcements via info bars, such as general product announcements or notices. This policy applies to SSMS releases based on Visual Studio 2026 or later. |
 
 ## Related content
 


### PR DESCRIPTION
Adds the new `InformationDisabled` feedback group policy to the **Configure feedback group policies for SQL Server Management Studio** article.

This machine policy lets administrators disable informational announcements shown via info bars. It's read from the shared `HKLM\SOFTWARE\Policies\Microsoft\VisualStudio\Feedback\InformationDisabled` registry value (same Feedback category as `SurveysDisabled` / `ProductFeedbackDisabled`). The matching VS ADMX/ADML entry is in microsoft/Visual-Studio-Administrative-Templates#186 and the VS docs row is in MicrosoftDocs/visualstudio-docs#11382.

**For reviewers:** the policy gating shipped in the Visual Studio 2026 (18.x) shell, so I noted "SSMS releases based on Visual Studio 2026 or later." Please confirm/adjust the exact minimum **SSMS** version that includes it, since I don't have the SSMS-to-VS version mapping.
