### PR TITLE
Adding a link to the SSMS 22 release notes on history page.

### DIFF
--- a/ssms/release-history.md
+++ b/ssms/release-history.md
@@ -26,6 +26,7 @@ For more information, see:
 
 Here are the release notes for different versions of SQL Server Management Studio:
 
+- [SQL Server Management Studio 22 release notes](release-notes-22.md)
 - [SQL Server Management Studio 21 release notes](release-notes-21.md)
 - [SQL Server Management Studio 20 release notes](release-notes-20.md)
 


### PR DESCRIPTION
This link is included on the rest of the pages with release note links, so I thought it made sense to add it here. This was the first page I loaded up when looking for the 22 notes.